### PR TITLE
-enabled auto update of cursor when using a loader manager

### DIFF
--- a/src/main/java/novoda/lib/sqliteprovider/provider/SQLiteContentProviderImpl.java
+++ b/src/main/java/novoda/lib/sqliteprovider/provider/SQLiteContentProviderImpl.java
@@ -172,8 +172,11 @@ public class SQLiteContentProviderImpl extends SQLiteContentProvider {
 
             Provider.v("==================== end of query =======================");
         }
-        return builder.query(getReadableDatabase(), projection, selection, selectionArgs, groupBy,
+        
+        Cursor cursor = builder.query(getReadableDatabase(), projection, selection, selectionArgs, groupBy,
                 having, sortOrder, limit);
+        cursor.setNotificationUri(getContext().getContentResolver(), uri);
+        return cursor;
     }
 
     protected ExtendedSQLiteQueryBuilder getSQLiteQueryBuilder() {


### PR DESCRIPTION
In its current state the SQLiteProvider does not enable auto update of the cursor when queried with a CursorLoader, this is a fix for this issue
