### PR TITLE
Update Gradle setup

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -6,14 +6,14 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.13.2'
+        classpath 'com.android.tools.build:gradle:1.2.2'
         classpath 'com.novoda:bintray-release:0.2.4'
     }
 }
 
 android {
-    compileSdkVersion 20
-    buildToolsVersion "20.0.0"
+    compileSdkVersion 22
+    buildToolsVersion "22.0.1"
     sourceSets {
         main {
             manifest.srcFile 'AndroidManifest.xml'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -21,6 +21,21 @@ android {
     }
 }
 
+repositories {
+    jcenter()
+}
+
+dependencies {
+    testCompile "org.scala-lang:scala-library:2.9.1"
+    testCompile "org.scalatest:scalatest_2.9.1:1.8.RC1"
+    testCompile "junit:junit:4.10"
+    testCompile "com.pivotallabs:robolectric:1.1"
+    testCompile "com.novocode:junit-interface:0.8"
+    testCompile "org.mockito:mockito-core:1.9.0"
+    testCompile "com.google.android:android:4.0.1.2"
+    testCompile "com.google.android:android-test:4.0.1.2"
+}
+
 publish {
     userOrg = 'novoda'
     groupId = 'com.novoda'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.3-all.zip


### PR DESCRIPTION
Updates the build setup to allow easier development in Android Studio

* Updates Gradle wrapper, build tools and target SDK
* Copies test dependencies from POM to `build.gradle`