### PR TITLE
Fix handling of multi-column unique constraints

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -6,14 +6,14 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.13.2'
+        classpath 'com.android.tools.build:gradle:1.2.2'
         classpath 'com.novoda:bintray-release:0.2.4'
     }
 }
 
 android {
-    compileSdkVersion 20
-    buildToolsVersion "20.0.0"
+    compileSdkVersion 22
+    buildToolsVersion "22.0.1"
     sourceSets {
         main {
             manifest.srcFile 'AndroidManifest.xml'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -21,6 +21,21 @@ android {
     }
 }
 
+repositories {
+    jcenter()
+}
+
+dependencies {
+    testCompile "org.scala-lang:scala-library:2.9.1"
+    testCompile "org.scalatest:scalatest_2.9.1:1.8.RC1"
+    testCompile "junit:junit:4.10"
+    testCompile "com.pivotallabs:robolectric:1.1"
+    testCompile "com.novocode:junit-interface:0.8"
+    testCompile "org.mockito:mockito-core:1.9.0"
+    testCompile "com.google.android:android:4.0.1.2"
+    testCompile "com.google.android:android-test:4.0.1.2"
+}
+
 publish {
     userOrg = 'novoda'
     groupId = 'com.novoda'

--- a/core/src/main/java/novoda/lib/sqliteprovider/provider/action/InsertHelper.java
+++ b/core/src/main/java/novoda/lib/sqliteprovider/provider/action/InsertHelper.java
@@ -6,7 +6,10 @@ import android.database.Cursor;
 import android.database.SQLException;
 import android.net.Uri;
 
+import java.util.List;
+
 import novoda.lib.sqliteprovider.sqlite.ExtendedSQLiteOpenHelper;
+import novoda.lib.sqliteprovider.util.Constraint;
 import novoda.lib.sqliteprovider.util.Log;
 import novoda.lib.sqliteprovider.util.UriUtils;
 
@@ -27,11 +30,11 @@ public class InsertHelper {
     public long insert(Uri uri, ContentValues values) {
         ContentValues insertValues = (values != null) ? new ContentValues(values) : new ContentValues();
         final String table = UriUtils.getItemDirID(uri);
-        final String firstConstrain = dbHelper.getFirstConstrain(table, insertValues);
+        final Constraint constraint = dbHelper.getFirstConstraint(table, insertValues);
         appendParentReference(uri, insertValues);
         long rowId = -1;
-        if (firstConstrain != null) {
-            rowId = tryUpdateWithConstrain(table, firstConstrain, insertValues);
+        if (constraint != null) {
+            rowId = tryUpdateWithConstraint(table, constraint, insertValues);
         } else {
             if (Log.Provider.warningLoggingEnabled()) {
                 Log.Provider.w("No constrain against URI: " + uri);
@@ -48,12 +51,16 @@ public class InsertHelper {
         throw new SQLException("Failed to insert row into " + uri);
     }
 
+    /**
+     * Use {@link #tryUpdateWithConstraint(String, Constraint, ContentValues)}
+     */
+    @Deprecated
     protected long tryUpdateWithConstrain(String table, String constrain, ContentValues values) {
         long rowId = -1;
         int update = dbHelper.getWritableDatabase().update(table, values, constrain + "=?",
-                new String[] {
-                values.getAsString(constrain)
-        });
+                new String[]{
+                        values.getAsString(constrain)
+                });
 
         if (Log.Provider.verboseLoggingEnabled()) {
             Log.Provider.v("Constrain " + constrain + " yield " + update);
@@ -64,6 +71,45 @@ public class InsertHelper {
         return rowId;
     }
 
+    protected long tryUpdateWithConstraint(String table, Constraint constraint, ContentValues values) {
+        long rowId = -1;
+        String whereClause = getWhereClause(constraint);
+        String[] whereArgs = getWhereArguments(constraint, values);
+        int update = dbHelper.getWritableDatabase().update(table, values, whereClause, whereArgs);
+
+        if (Log.Provider.verboseLoggingEnabled()) {
+            Log.Provider.v("Constrain " + constraint + " yield " + update);
+        }
+        if (update > 0) {
+            rowId = getRowIdForUpdate(table, constraint, values);
+        }
+        return rowId;
+    }
+
+    private String getWhereClause(Constraint constraint) {
+        List<String> columns = constraint.getColumns();
+        String whereClause = "";
+        for (int i = 0; i < columns.size(); i++) {
+            String column = columns.get(i);
+            if (i > 0) {
+                whereClause += " AND ";
+            }
+            whereClause += column + "=?";
+        }
+        return whereClause;
+    }
+
+    private String[] getWhereArguments(Constraint constraint, ContentValues values) {
+        List<String> columns = constraint.getColumns();
+        int columnCount = columns.size();
+        String[] whereArgs = new String[columnCount];
+        for (int i = 0; i < columnCount; i++) {
+            String column = columns.get(i);
+            whereArgs[i] = values.getAsString(column);
+        }
+        return whereArgs;
+    }
+
     /**
      * Will get the Row id from the latest update.
      *
@@ -72,12 +118,10 @@ public class InsertHelper {
      * @param values
      * @return
      */
-    private long getRowIdForUpdate(String table, String constrain, ContentValues values) {
-        final Cursor cur = dbHelper.getReadableDatabase().query(table, new String[] {
+    private long getRowIdForUpdate(String table, Constraint constraint, ContentValues values) {
+        final Cursor cur = dbHelper.getReadableDatabase().query(table, new String[]{
                 "rowid"
-        }, constrain + "=?", new String[] {
-                values.getAsString(constrain)
-        }, null, null, null);
+        }, getWhereClause(constraint), getWhereArguments(constraint, values), null, null, null);
         if (!cur.moveToFirst()) {
             return -1;
         }

--- a/core/src/main/java/novoda/lib/sqliteprovider/sqlite/IDatabaseMetaInfo.java
+++ b/core/src/main/java/novoda/lib/sqliteprovider/sqlite/IDatabaseMetaInfo.java
@@ -4,19 +4,28 @@ package novoda.lib.sqliteprovider.sqlite;
 import java.util.List;
 import java.util.Map;
 
+import novoda.lib.sqliteprovider.util.Constraint;
+
 public interface IDatabaseMetaInfo {
 
-    public enum SQLiteType {
-        NULL, INTEGER, REAL, TEXT, BLOB, NUMERIC
-    }
 
+
+    public enum SQLiteType {
+        NULL, INTEGER, REAL, TEXT, BLOB, NUMERIC;
+    }
     Map<String, SQLiteType> getColumns(String table);
 
     List<String> getTables();
 
     List<String> getForeignTables(String table);
 
+    /**
+     * Use {@link #getUniqueConstraints(String)}
+     */
+    @Deprecated
     List<String> getUniqueConstrains(String table);
+
+    List<Constraint> getUniqueConstraints(String table);
 
     Map<String, String> getProjectionMap(String parent, String... foreignTables);
 

--- a/core/src/main/java/novoda/lib/sqliteprovider/util/Constraint.java
+++ b/core/src/main/java/novoda/lib/sqliteprovider/util/Constraint.java
@@ -2,10 +2,10 @@ package novoda.lib.sqliteprovider.util;
 
 import java.util.List;
 
-class Constraint {
+public class Constraint {
     private final List<String> columns;
 
-    private Constraint(List<String> columns) {
+    public Constraint(List<String> columns) {
         this.columns = columns;
     }
 

--- a/core/src/main/java/novoda/lib/sqliteprovider/util/Constraint.java
+++ b/core/src/main/java/novoda/lib/sqliteprovider/util/Constraint.java
@@ -1,0 +1,15 @@
+package novoda.lib.sqliteprovider.util;
+
+import java.util.List;
+
+class Constraint {
+    private final List<String> columns;
+
+    private Constraint(List<String> columns) {
+        this.columns = columns;
+    }
+
+    public List<String> getColumns() {
+        return columns;
+    }
+}

--- a/core/src/main/java/novoda/lib/sqliteprovider/util/DBUtils.java
+++ b/core/src/main/java/novoda/lib/sqliteprovider/util/DBUtils.java
@@ -4,10 +4,15 @@ package novoda.lib.sqliteprovider.util;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 
-import novoda.lib.sqliteprovider.sqlite.IDatabaseMetaInfo.SQLiteType;
-
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
+
+import novoda.lib.sqliteprovider.sqlite.IDatabaseMetaInfo.SQLiteType;
 
 public final class DBUtils {
 
@@ -19,7 +24,7 @@ public final class DBUtils {
 
     private static final String PRGAMA_INDEX_INFO = "PRAGMA index_info('%1$s');";
 
-    private static List<String> defaultTables = Arrays.asList(new String[] {
+    private static List<String> defaultTables = Arrays.asList(new String[]{
             "android_metadata"
     });
 
@@ -113,6 +118,11 @@ public final class DBUtils {
         return sqliteVersion.toString();
     }
 
+
+    /**
+     * Use {@link #getUniqueConstraints(SQLiteDatabase, String)}
+     */
+    @Deprecated
     public static List<String> getUniqueConstrains(SQLiteDatabase db, String table) {
         List<String> constrains = new ArrayList<String>();
         final Cursor pragmas = db.rawQuery(String.format(PRGAMA_INDEX_LIST, table), null);
@@ -129,5 +139,26 @@ public final class DBUtils {
         }
         pragmas.close();
         return constrains;
+    }
+
+
+    public static List<Constraint> getUniqueConstraints(SQLiteDatabase db, String table) {
+        List<Constraint> constraints = new ArrayList<Constraint>();
+        final Cursor indexCursor = db.rawQuery(String.format(PRGAMA_INDEX_LIST, table), null);
+        while (indexCursor.moveToNext()) {
+            int isUnique = indexCursor.getInt(2);
+            if (isUnique == 1) {
+                String indexName = indexCursor.getString(1);
+                final Cursor columnCursor = db.rawQuery(String.format(PRGAMA_INDEX_INFO, indexName), null);
+                List<String> columns = new ArrayList<>(columnCursor.getCount());
+                while (columnCursor.moveToNext()) {
+                    String columnName = columnCursor.getString(2);
+                    columns.add(columnName);
+                }
+                columnCursor.close();
+            }
+        }
+        indexCursor.close();
+        return constraints;
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.3-all.zip


### PR DESCRIPTION
### Problem

When inserting into a table an update is tried first to provide upsert functionality. In the WHERE clause of the update, only the first column of any multi-column constraint is used.

For this table:
```sql
CREATE TABLE IF NOT EXISTS 'superhero' (
        _id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
        name TEXT NOT NULL,
        power TEXT NOT NULL,
        comic_company TEXT NOT NULL,
        UNIQUE (name, comic_company) ON CONFLICT REPLACE
);
```
only one entry would be allowed for each `name` value, when really one entry should be allowed for each combination of `name` and `comic_company` values.

### Solution

Create the WHERE clause using every column in the constraint.

* Adds a `Constraint` class which wraps a list of column names
* Uses this class instead of a single `String` where needed
* Deprecates the existing methods that use `String` instead of `Constraint`