### PR TITLE
Bulk insert should notify observers only once

### DIFF
--- a/core/src/main/java/novoda/lib/sqliteprovider/provider/SQLiteContentProviderImpl.java
+++ b/core/src/main/java/novoda/lib/sqliteprovider/provider/SQLiteContentProviderImpl.java
@@ -63,14 +63,16 @@ public class SQLiteContentProviderImpl extends SQLiteContentProvider {
 
     @Override
     protected Uri insertInTransaction(Uri uri, ContentValues values) {
-        return insertInTransaction(uri, values, true);
+        Uri insertUri = insertSilently(uri, values);
+        notifyUriChange(uri);
+        return insertUri;
     }
 
     @Override
     protected int bulkInsertInTransaction(Uri uri, ContentValues[] values) {
         int rowsCreated = 0;
         for (ContentValues value : values) {
-            Uri insertUri = insertInTransaction(uri, value, false);
+            Uri insertUri = insertSilently(uri, value);
             if (insertUri != null) {
                 rowsCreated++;
             }
@@ -80,13 +82,9 @@ public class SQLiteContentProviderImpl extends SQLiteContentProvider {
         return rowsCreated;
     }
 
-    private Uri insertInTransaction(Uri uri, ContentValues values, boolean shouldNotifyChange) {
+    private Uri insertSilently(Uri uri, ContentValues values) {
         long rowId = helper.insert(uri, values);
-        Uri newUri = ContentUris.withAppendedId(uri, rowId);
-        if (shouldNotifyChange) {
-            notifyUriChange(newUri);
-        }
-        return newUri;
+        return ContentUris.withAppendedId(uri, rowId);
     }
 
     @Override

--- a/demo-extended/src/main/AndroidManifest.xml
+++ b/demo-extended/src/main/AndroidManifest.xml
@@ -26,6 +26,9 @@
       android:name=".ui.AddFireworkActivity"
       android:label="@string/activity_label_add_new_firework" />
     <activity
+      android:name=".ui.AddBulkFireworksActivity"
+      android:label="@string/activity_label_add_bulk_fireworks" />
+    <activity
       android:name=".ui.FindFireworkWithPkActivity"
       android:label="@string/activity_label_find_firework" />
     <activity

--- a/demo-extended/src/main/java/com/novoda/sqliteprovider/demo/domain/UseCaseFactory.java
+++ b/demo-extended/src/main/java/com/novoda/sqliteprovider/demo/domain/UseCaseFactory.java
@@ -10,28 +10,30 @@ public final class UseCaseFactory {
     }
 
     public enum UseCase {
-        ADD, ONE_TO_MANY, PRIMARY_KEY_LOOKUP, SELECT_ALL, DISTINCT, LIMIT, GROUP_HAVING;
+        ADD, BULK_ADD, ONE_TO_MANY, PRIMARY_KEY_LOOKUP, SELECT_ALL, DISTINCT, LIMIT, GROUP_HAVING;
     }
 
     public static UseCaseInfo getInfo(UseCase useCase) {
         switch (useCase) {
-        case ADD:
-            return createUseCaseInfo(FireworkUriConstants.ADD_FIREWORK, RawSql.INSERT_FIREWORK);
-        case ONE_TO_MANY:
-            return createUseCaseInfo(FireworkUriConstants.ONE_TO_MANY_SEARCH, RawSql.SELECT_USING_SHOP_FOREIGN_KEY);
-        case PRIMARY_KEY_LOOKUP:
-            return createUseCaseInfo(FireworkUriConstants.PRIMARY_KEY_SEARCH, RawSql.SELECT_USING_PRIMARY_KEY);
-        case SELECT_ALL:
-            return createUseCaseInfo(FireworkUriConstants.VIEW_ALL_SEARCH, RawSql.SELECT_ALL);
-        case DISTINCT:
-            return createUseCaseInfo(FireworkUriConstants.UNIQUE_SEARCH, RawSql.DISTINCT);
-        case LIMIT:
-            return createUseCaseInfo(FireworkUriConstants.LIMIT_3, RawSql.LIMIT);
-        case GROUP_HAVING:
-            return createUseCaseInfo(FireworkUriConstants.GROUP_BY_SEARCH, RawSql.GROUP_BY);
-        default:
-            Log.e("UseCase " + useCase.toString() + " not found, returning null safe case.");
-            return UseCaseInfo.getNullSafe();
+            case ADD:
+                return createUseCaseInfo(FireworkUriConstants.ADD_FIREWORK, RawSql.INSERT_FIREWORK);
+            case BULK_ADD:
+                return createUseCaseInfo(FireworkUriConstants.ADD_FIREWORK, RawSql.BULK_INSERT_FIREWORKS);
+            case ONE_TO_MANY:
+                return createUseCaseInfo(FireworkUriConstants.ONE_TO_MANY_SEARCH, RawSql.SELECT_USING_SHOP_FOREIGN_KEY);
+            case PRIMARY_KEY_LOOKUP:
+                return createUseCaseInfo(FireworkUriConstants.PRIMARY_KEY_SEARCH, RawSql.SELECT_USING_PRIMARY_KEY);
+            case SELECT_ALL:
+                return createUseCaseInfo(FireworkUriConstants.VIEW_ALL_SEARCH, RawSql.SELECT_ALL);
+            case DISTINCT:
+                return createUseCaseInfo(FireworkUriConstants.UNIQUE_SEARCH, RawSql.DISTINCT);
+            case LIMIT:
+                return createUseCaseInfo(FireworkUriConstants.LIMIT_3, RawSql.LIMIT);
+            case GROUP_HAVING:
+                return createUseCaseInfo(FireworkUriConstants.GROUP_BY_SEARCH, RawSql.GROUP_BY);
+            default:
+                Log.e("UseCase " + useCase.toString() + " not found, returning null safe case.");
+                return UseCaseInfo.getNullSafe();
         }
     }
 

--- a/demo-extended/src/main/java/com/novoda/sqliteprovider/demo/loader/FireworksBulkSaver.java
+++ b/demo-extended/src/main/java/com/novoda/sqliteprovider/demo/loader/FireworksBulkSaver.java
@@ -1,0 +1,30 @@
+package com.novoda.sqliteprovider.demo.loader;
+
+import android.content.Context;
+import android.support.v4.content.AsyncTaskLoader;
+
+import com.novoda.sqliteprovider.demo.domain.Firework;
+import com.novoda.sqliteprovider.demo.persistance.FireworkWriter;
+
+import java.util.List;
+
+public class FireworksBulkSaver extends AsyncTaskLoader<List<Firework>> {
+
+    private final FireworkWriter writer;
+    private final List<Firework> fireworks;
+    public static final int LOADER_ID = 123;
+
+    public FireworksBulkSaver(Context context, FireworkWriter writer, List<Firework> fireworks) {
+        super(context);
+        this.writer = writer;
+        this.fireworks = fireworks;
+        forceLoad();
+    }
+
+    @Override
+    public List<Firework> loadInBackground() {
+        writer.saveFireworks(fireworks);
+        return fireworks;
+    }
+
+}

--- a/demo-extended/src/main/java/com/novoda/sqliteprovider/demo/persistance/DatabaseConstants.java
+++ b/demo-extended/src/main/java/com/novoda/sqliteprovider/demo/persistance/DatabaseConstants.java
@@ -38,5 +38,10 @@ public final class DatabaseConstants {
         public static final String LIMIT = "SELECT * FROM firework LIMIT 3;";
 
         public static final String DISTINCT = "SELECT DISTINCT name, ftype, color, noise, price FROM firework;";
+        public static final String BULK_INSERT_FIREWORKS = "BEGIN TRANSACTION\n" +
+                "FOR Times DO\n" +
+                "INSERT INTO firework " + "(name, color, noise, ftype, price, " +
+                "shop_id) VALUES (Na, Co, No, Ft, Pr, Sh);\n" +
+                "END TRANSACTION";
     }
 }

--- a/demo-extended/src/main/java/com/novoda/sqliteprovider/demo/persistance/DatabaseWriter.java
+++ b/demo-extended/src/main/java/com/novoda/sqliteprovider/demo/persistance/DatabaseWriter.java
@@ -18,6 +18,15 @@ public class DatabaseWriter {
         saveDataToTable(DatabaseConstants.TBL_FIREWORKS, values);
     }
 
+    public void bulkSaveDataToFireworksTable(ContentValues[] values) {
+        bulkSaveDataToTable(DatabaseConstants.TBL_FIREWORKS, values);
+    }
+
+    private void bulkSaveDataToTable(String table, ContentValues[] values) {
+        Uri uri = createUri(table);
+        contentResolver.bulkInsert(uri, values);
+    }
+
     private void saveDataToTable(String table, ContentValues values) {
         Uri uri = createUri(table);
         contentResolver.insert(uri, values);

--- a/demo-extended/src/main/java/com/novoda/sqliteprovider/demo/persistance/FireworkWriter.java
+++ b/demo-extended/src/main/java/com/novoda/sqliteprovider/demo/persistance/FireworkWriter.java
@@ -4,6 +4,9 @@ import android.content.ContentValues;
 
 import com.novoda.sqliteprovider.demo.domain.Firework;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static com.novoda.sqliteprovider.demo.persistance.DatabaseConstants.Fireworks.*;
 
 public class FireworkWriter {
@@ -15,6 +18,21 @@ public class FireworkWriter {
     }
 
     public void saveFirework(Firework firework) {
+        ContentValues values = createContentValuesFrom(firework);
+        databaseWriter.saveDataToFireworksTable(values);
+    }
+
+    public void saveFireworks(List<Firework> fireworks) {
+        List<ContentValues> valuesArray = new ArrayList<>();
+        for (Firework firework : fireworks) {
+            ContentValues values = createContentValuesFrom(firework);
+            valuesArray.add(values);
+        }
+
+        databaseWriter.bulkSaveDataToFireworksTable(valuesArray.toArray(new ContentValues[fireworks.size()]));
+    }
+
+    private ContentValues createContentValuesFrom(Firework firework) {
         ContentValues values = new ContentValues();
         values.put(COL_NAME, firework.getName());
         values.put(COL_COLOR, firework.getColor());
@@ -22,8 +40,7 @@ public class FireworkWriter {
         values.put(COL_TYPE, firework.getType());
         values.put(COL_PRICE, firework.getPrice());
         values.put(COL_SHOP, 1);
-
-        databaseWriter.saveDataToFireworksTable(values);
+        return values;
     }
 
 }

--- a/demo-extended/src/main/java/com/novoda/sqliteprovider/demo/ui/AddBulkFireworksActivity.java
+++ b/demo-extended/src/main/java/com/novoda/sqliteprovider/demo/ui/AddBulkFireworksActivity.java
@@ -1,0 +1,75 @@
+package com.novoda.sqliteprovider.demo.ui;
+
+import android.os.Bundle;
+import android.support.v4.app.LoaderManager.LoaderCallbacks;
+import android.support.v4.content.Loader;
+import android.text.TextUtils;
+import android.widget.Toast;
+
+import com.novoda.sqliteprovider.demo.R;
+import com.novoda.sqliteprovider.demo.domain.Firework;
+import com.novoda.sqliteprovider.demo.domain.UseCaseFactory;
+import com.novoda.sqliteprovider.demo.loader.FireworkSaver;
+import com.novoda.sqliteprovider.demo.loader.FireworksBulkSaver;
+import com.novoda.sqliteprovider.demo.persistance.DatabaseConstants;
+import com.novoda.sqliteprovider.demo.ui.base.NovodaActivity;
+import com.novoda.sqliteprovider.demo.ui.fragment.AddBulkFireworksFragment.AddBulkFireworksListener;
+import com.novoda.sqliteprovider.demo.ui.fragment.UriSqlFragment;
+
+import java.util.List;
+
+public class AddBulkFireworksActivity extends NovodaActivity implements AddBulkFireworksListener, LoaderCallbacks<List<Firework>> {
+
+    private UriSqlFragment uriSqlFragment;
+    private List<Firework> fireworks;
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_add_bulk_fireworks);
+
+        uriSqlFragment = (UriSqlFragment) getSupportFragmentManager().findFragmentById(R.id.fragment_uri_sql);
+        uriSqlFragment.setInfo(UseCaseFactory.UseCase.BULK_ADD);
+    }
+
+    @Override
+    public void onEmptyInput() {
+        Toast.makeText(this, "Fill in the number of fireworks to add", Toast.LENGTH_SHORT).show();
+    }
+
+    @Override
+    public void onBulkAddClick(List<Firework> fireworks) {
+        this.fireworks = fireworks;
+        getSupportLoaderManager().initLoader(FireworkSaver.LOADER_ID, null, this);
+    }
+
+    @Override
+    public Loader<List<Firework>> onCreateLoader(int id, Bundle args) {
+        return new FireworksBulkSaver(this, getApp().getFireworkWriter(), fireworks);
+    }
+
+    @Override
+    public void onLoadFinished(Loader<List<Firework>> loader, List<Firework> data) {
+        Toast.makeText(this, data.size() + " fireworks added!", Toast.LENGTH_LONG).show();
+        uriSqlFragment.updateSql(createSQL(data));
+    }
+
+    private String createSQL(List<Firework> data) {
+        Firework firework = data.get(0);
+        return TextUtils.replace(
+                DatabaseConstants.RawSql.BULK_INSERT_FIREWORKS,
+                new String[]{"Times", "Na", "Co", "No", "Ft", "Pr", "Sh"},
+                new CharSequence[]{
+                        String.valueOf(data.size()),
+                        firework.getName(),
+                        firework.getColor(),
+                        firework.getNoise(),
+                        firework.getType(),
+                        String.valueOf(firework.getPrice()), "1"
+                }).toString();
+    }
+
+    @Override
+    public void onLoaderReset(Loader<List<Firework>> loader) {
+    }
+}

--- a/demo-extended/src/main/java/com/novoda/sqliteprovider/demo/ui/MainActivity.java
+++ b/demo-extended/src/main/java/com/novoda/sqliteprovider/demo/ui/MainActivity.java
@@ -32,6 +32,12 @@ public class MainActivity extends NovodaActivity implements DemoMenu {
 
     @Override
     @FromXML
+    public void onBulkAddFireworksClick(View view) {
+        startActivity(AddBulkFireworksActivity.class);
+    }
+
+    @Override
+    @FromXML
     public void onFindFireworkWithPrimaryKeyClick(View button) {
         startActivity(FindFireworkWithPkActivity.class);
     }

--- a/demo-extended/src/main/java/com/novoda/sqliteprovider/demo/ui/fragment/AddBulkFireworksFragment.java
+++ b/demo-extended/src/main/java/com/novoda/sqliteprovider/demo/ui/fragment/AddBulkFireworksFragment.java
@@ -1,0 +1,84 @@
+package com.novoda.sqliteprovider.demo.ui.fragment;
+
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v4.app.Fragment;
+import android.text.TextUtils;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.EditText;
+
+import com.novoda.sqliteprovider.demo.R;
+import com.novoda.sqliteprovider.demo.domain.Firework;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class AddBulkFireworksFragment extends Fragment {
+
+    private EditText fireworksNumberEditText;
+
+    @Nullable
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        View root = inflater.inflate(R.layout.fragment_add_bulk_fireworks, container, false);
+
+        fireworksNumberEditText = (EditText) root.findViewById(R.id.add_bulk_fireworks_number);
+        root.findViewById(R.id.add_bulk_fireworks_add_button).setOnClickListener(onAddBulkFireworksClick);
+        return root;
+    }
+
+    private final View.OnClickListener onAddBulkFireworksClick = new View.OnClickListener() {
+        @Override
+        public void onClick(View v) {
+            onAddBulkFireworksClick();
+        }
+    };
+
+    private void onAddBulkFireworksClick() {
+        if (fieldsArentFilledIn()) {
+            notifyActivityEmptyFields();
+            return;
+        }
+
+        int numberOfFireworks = Integer.valueOf(fireworksNumberEditText.getText().toString());
+        List<Firework> fireworks = new ArrayList<>();
+        for (int i = 0; i < numberOfFireworks; i++) {
+            Firework firework = new Firework("BulkFirework", "blue", "bulk", "bang", 99.9);
+            fireworks.add(firework);
+        }
+        notifyActivityFireworksClicked(fireworks);
+        clearFields();
+    }
+
+    private void notifyActivityFireworksClicked(List<Firework> fireworks) {
+        if (getActivity() instanceof AddBulkFireworksListener) {
+            ((AddBulkFireworksListener) getActivity()).onBulkAddClick(fireworks);
+        }
+    }
+
+    private void clearFields() {
+        fireworksNumberEditText.setText("");
+    }
+
+    private void notifyActivityEmptyFields() {
+        if (getActivity() instanceof AddBulkFireworksListener) {
+            ((AddBulkFireworksListener) getActivity()).onEmptyInput();
+        }
+    }
+
+    private boolean fieldsArentFilledIn() {
+        return checkForInput(fireworksNumberEditText);
+    }
+
+    private boolean checkForInput(EditText editText) {
+        return TextUtils.isEmpty(editText.getText()) || Integer.valueOf(editText.getText().toString()) == 0;
+    }
+
+    public interface AddBulkFireworksListener {
+        void onEmptyInput();
+
+        void onBulkAddClick(List<Firework> fireworks);
+    }
+}

--- a/demo-extended/src/main/java/com/novoda/sqliteprovider/demo/ui/input/DemoMenu.java
+++ b/demo-extended/src/main/java/com/novoda/sqliteprovider/demo/ui/input/DemoMenu.java
@@ -8,6 +8,8 @@ public interface DemoMenu {
 
     void onAddFireworkClick(View button);
 
+    void onBulkAddFireworksClick(View button);
+
     void onFindFireworkWithPrimaryKeyClick(View button);
 
     void onFindAllFireworksFromOneShopClick(View button);

--- a/demo-extended/src/main/res/layout/activity_add_bulk_fireworks.xml
+++ b/demo-extended/src/main/res/layout/activity_add_bulk_fireworks.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+  style="@style/wrap_w_wrap_h">
+
+  <LinearLayout
+    style="@style/wrap_w_wrap_h"
+    android:orientation="vertical">
+
+    <fragment
+      android:id="@+id/fragment_uri_sql"
+      style="@style/wrap_w_wrap_h"
+      class="com.novoda.sqliteprovider.demo.ui.fragment.UriSqlFragment" />
+
+    <fragment
+      android:id="@+id/fragment_add_bulk_fireworks"
+      style="@style/match_w_wrap_h"
+      class="com.novoda.sqliteprovider.demo.ui.fragment.AddBulkFireworksFragment" />
+  </LinearLayout>
+
+</ScrollView>

--- a/demo-extended/src/main/res/layout/activity_main.xml
+++ b/demo-extended/src/main/res/layout/activity_main.xml
@@ -20,6 +20,12 @@
     <Button
       style="@style/match_w_wrap_h"
       android:layout_margin="@dimen/norm_spacing"
+      android:onClick="onBulkAddFireworksClick"
+      android:text="@string/button_main_bulk_add_fireworks" />
+
+    <Button
+      style="@style/match_w_wrap_h"
+      android:layout_margin="@dimen/norm_spacing"
       android:onClick="onFindFireworkWithPrimaryKeyClick"
       android:text="@string/button_main_find_using_primary_key" />
 

--- a/demo-extended/src/main/res/layout/fragment_add_bulk_fireworks.xml
+++ b/demo-extended/src/main/res/layout/fragment_add_bulk_fireworks.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  android:orientation="vertical"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent">
+
+  <TextView
+    style="@style/wrap_w_wrap_h"
+    android:padding="@dimen/norm_spacing"
+    android:text="@string/activity_add_bulk_fireworks_text" />
+
+  <EditText
+    android:id="@+id/add_bulk_fireworks_number"
+    style="@style/match_w_wrap_h"
+    android:layout_margin="@dimen/norm_spacing"
+    android:hint="@string/activity_add_bulk_fireworks_input_number"
+    android:imeOptions="actionNext"
+    android:inputType="number"
+    android:maxLines="1" />
+
+  <Button
+    android:id="@+id/add_bulk_fireworks_add_button"
+    style="@style/match_w_wrap_h"
+    android:layout_margin="@dimen/norm_spacing"
+    android:hint="@string/button_add_fireworks" />
+
+</LinearLayout>

--- a/demo-extended/src/main/res/values/strings.xml
+++ b/demo-extended/src/main/res/values/strings.xml
@@ -4,6 +4,7 @@
   <string name="app_name">SQLiteProviderDemo</string>
   <string name="button_main_view_all_fireworks">View all Fireworks</string>
   <string name="button_main_add_firework">Add a new Firework</string>
+  <string name="button_main_bulk_add_fireworks">Add bulk Fireworks</string>
   <string name="activity_add_firework_text">Add a firework to the firework table in your database</string>
   <string name="activity_add_firework_input_title_name">Name:</string>
   <string name="activity_add_firework_input_title_color">Color:</string>
@@ -11,6 +12,7 @@
   <string name="activity_add_firework_input_title_noise">Noise:</string>
   <string name="activity_add_firework_input_title_price">Price:</string>
   <string name="button_add_firework">Add Firework</string>
+  <string name="button_add_fireworks">Add Fireworks</string>
   <string name="button_main_find_using_primary_key">Find firework using Primary Key</string>
   <string name="button_main_find_all_fireworks_from_one_shop">Find all fireworks from one shop (One to Many)</string>
   <string name="button_main_group_fireworks_by_shop_id">Total firework price Grouped by Shop (Group / Having)</string>
@@ -26,6 +28,7 @@
   <string name="activity_label_firework">Firework Details</string>
   <string name="activity_label_all_fireworks">All Fireworks</string>
   <string name="activity_label_add_new_firework">Add New Firework</string>
+  <string name="activity_label_add_bulk_fireworks">Add bulk Fireworks</string>
   <string name="activity_label_find_firework">Find Firework</string>
   <string name="activity_find_firework_with_pk_firework_primary_key_input_title">Firework Primary Key:</string>
   <string name="activity_find_firework_with_pk_firework_primary_key_input_hint">Primary Key</string>
@@ -38,5 +41,7 @@
   <string name="activity_label_limit">Limit of 3</string>
   <string name="activity_label_distinct_fireworks">Distinct Fireworks</string>
   <string name="activity_label_find_firework_from_shop">Find Fireworks with shop PK</string>
+  <string name="activity_add_bulk_fireworks_text">Bulk add random fireworks in the firework table</string>
+  <string name="activity_add_bulk_fireworks_input_number">Number of random fireworks</string>
 
 </resources>


### PR DESCRIPTION
## Problem

The `bulkInsert` method was notifying observers for every insert into the database. This is conceptually wrong, bulk insert should only notify once, at the end of the transaction. 

## Solution 

We now notify only once, at the end of the transaction. 

Added a demo activity in the app example as well:

![sqlite_provider](https://cloud.githubusercontent.com/assets/913571/7441055/a3c29488-f0cd-11e4-97d4-b8da989b24aa.gif)

