### PR TITLE
Update bintray plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ proguard/
 # Google play publishing plugin
 core/src/main/play/
 
+tmp

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:1.2.2'
-        classpath 'com.novoda:bintray-release:0.2.4'
+        classpath 'com.novoda:bintray-release:0.2.10'
     }
 }
 


### PR DESCRIPTION
Updates the version of the [bintray-release](https://github.com/novoda/bintray-release) plugin to 0.2.10 which should fix our issue with test dependencies being pulled into the POM. [(plugin issue)](https://github.com/novoda/bintray-release/issues/31)

## Generated POM (Before - 0.2.4)

```xml
<?xml version="1.0" encoding="UTF-8"?>
<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <modelVersion>4.0.0</modelVersion>
  <groupId>com.novoda</groupId>
  <artifactId>sqlite-provider</artifactId>
  <version>1.0.92</version>
  <packaging>aar</packaging>
  <dependencies>
    <dependency>
      <groupId>junit</groupId>
      <artifactId>junit</artifactId>
      <version>4.12</version>
      <scope>runtime</scope>
    </dependency>
    <dependency>
      <groupId>org.robolectric</groupId>
      <artifactId>robolectric</artifactId>
      <version>2.2</version>
      <scope>runtime</scope>
    </dependency>
    <dependency>
      <groupId>org.mockito</groupId>
      <artifactId>mockito-core</artifactId>
      <version>1.10.19</version>
      <scope>runtime</scope>
    </dependency>
  </dependencies>
</project>

```

## Generated POM (After - 0.2.10)

```xml
<?xml version="1.0" encoding="UTF-8"?>
<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <modelVersion>4.0.0</modelVersion>
  <groupId>com.novoda</groupId>
  <artifactId>sqlite-provider</artifactId>
  <version>1.0.92</version>
  <packaging>aar</packaging>
</project>
```