### PR TITLE
Added getNotificationUri()

### DIFF
--- a/core/src/main/java/novoda/lib/sqliteprovider/provider/SQLiteContentProviderImpl.java
+++ b/core/src/main/java/novoda/lib/sqliteprovider/provider/SQLiteContentProviderImpl.java
@@ -166,7 +166,7 @@ public class SQLiteContentProviderImpl extends SQLiteContentProvider {
         logger.logEnd(projection, selection, selectionArgs, sortOrder, builder, groupBy, having, limit, autoproj);
 
         Cursor cursor = builder.query(getReadableDatabase(), projection, selection, selectionArgs, groupBy, having, sortOrder, limit);
-        cursor.setNotificationUri(getContext().getContentResolver(), uri);
+        cursor.setNotificationUri(getContext().getContentResolver(), getNotificationUri(uri));
         return cursor;
     }
 
@@ -177,5 +177,9 @@ public class SQLiteContentProviderImpl extends SQLiteContentProvider {
     @Override
     protected SQLiteDatabase.CursorFactory getCursorFactory() {
         return null;
+    }
+
+    protected Uri getNotificationUri(Uri uri){
+        return uri;
     }
 }

--- a/core/src/test/java/novoda/lib/sqliteprovider/provider/SQLiteProviderLocalTest.java
+++ b/core/src/test/java/novoda/lib/sqliteprovider/provider/SQLiteProviderLocalTest.java
@@ -1,5 +1,6 @@
 package novoda.lib.sqliteprovider.provider;
 
+import android.content.ContentResolver;
 import android.content.ContentUris;
 import android.content.ContentValues;
 import android.content.Context;
@@ -259,6 +260,12 @@ public class SQLiteProviderLocalTest {
 
     }
 
+    @Test
+    public void testProvidedNotificationUriSetCorrectly() {
+        query("test.com/view1");
+        verify(mockCursor).setNotificationUri((ContentResolver) anyObject(), eq(Uri.parse("content://test.com/table1")));
+    }
+
     @Implements(ContentUris.class)
     static class ShadowContentUris {
 
@@ -343,6 +350,11 @@ public class SQLiteProviderLocalTest {
         @Override
         public void notifyUriChange(Uri uri) {
             notifyChangeCounter++;
+        }
+
+        @Override
+        protected Uri getNotificationUri(Uri uri) {
+            return Uri.parse("content://test.com/table1");
         }
     }
 }


### PR DESCRIPTION
allows SQL views to be notified when a table is updated.

In the scenario when an SQLite view is queried the notification URI must be a concrete table. This method enables this.