### PR TITLE
Optional yieldIfContendedSafely() on bulkInsert

### DIFF
--- a/core/src/main/java/novoda/lib/sqliteprovider/provider/SQLiteContentProviderImpl.java
+++ b/core/src/main/java/novoda/lib/sqliteprovider/provider/SQLiteContentProviderImpl.java
@@ -28,6 +28,7 @@ public class SQLiteContentProviderImpl extends SQLiteContentProvider {
     private static final String LIMIT = "limit";
     private static final String EXPAND = "expand";
     private static final String DISTINCT = "distinct";
+    private static final String ALLOW_YIELD = "allowYield";
 
     private InsertHelper helper;
     private final ImplLogger logger;
@@ -70,13 +71,17 @@ public class SQLiteContentProviderImpl extends SQLiteContentProvider {
 
     @Override
     protected int bulkInsertInTransaction(Uri uri, ContentValues[] values) {
+        String allowYield = uri.getQueryParameter(ALLOW_YIELD);
+        boolean shouldYield = allowYield == null || Boolean.parseBoolean(allowYield);
         int rowsCreated = 0;
         for (ContentValues value : values) {
             Uri insertUri = insertSilently(uri, value);
             if (insertUri != null) {
                 rowsCreated++;
             }
-            getWritableDatabase().yieldIfContendedSafely();
+            if (shouldYield) {
+                getWritableDatabase().yieldIfContendedSafely();
+            }
         }
         notifyUriChange(uri);
         return rowsCreated;

--- a/core/src/test/java/novoda/lib/sqliteprovider/provider/SQLiteProviderLocalTest.java
+++ b/core/src/test/java/novoda/lib/sqliteprovider/provider/SQLiteProviderLocalTest.java
@@ -21,9 +21,9 @@ import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.shadows.ShadowContentUris;
 
+import novoda.lib.sqliteprovider.RoboRunner;
 import novoda.lib.sqliteprovider.sqlite.ExtendedSQLiteOpenHelper;
 import novoda.lib.sqliteprovider.sqlite.ExtendedSQLiteQueryBuilder;
-import novoda.lib.sqliteprovider.RoboRunner;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
@@ -257,6 +257,39 @@ public class SQLiteProviderLocalTest {
 
         assertThat(notifyChangeCounter, is(deleteSize));
 
+    }
+
+    @Test
+    public void testBulkInsertDoesYieldByDefault() {
+        when(db.insert(anyString(), anyString(), (ContentValues) anyObject())).thenReturn(2L);
+        int bulkSize = 100;
+        ContentValues[] bulkToInsert = createContentValuesArray(bulkSize);
+
+        bulkInsert("test.com/table1", bulkToInsert);
+
+        verify(db, times(bulkSize)).yieldIfContendedSafely();
+    }
+
+    @Test
+    public void testWhenSpecifyingAllowYieldQueryParameterAsTrueThanBulkInsertDoesYield() {
+        when(db.insert(anyString(), anyString(), (ContentValues) anyObject())).thenReturn(2L);
+        int bulkSize = 100;
+        ContentValues[] bulkToInsert = createContentValuesArray(bulkSize);
+
+        bulkInsert("test.com/table1?allowYield=true", bulkToInsert);
+
+        verify(db, times(bulkSize)).yieldIfContendedSafely();
+    }
+
+    @Test
+    public void testWhenSpecifyingAllowYieldQueryParameterAsFalseThanBulkInsertDoesNotYield() {
+        when(db.insert(anyString(), anyString(), (ContentValues) anyObject())).thenReturn(2L);
+        int bulkSize = 100;
+        ContentValues[] bulkToInsert = createContentValuesArray(bulkSize);
+
+        bulkInsert("test.com/table1?allowYield=false", bulkToInsert);
+
+        verify(db, never()).yieldIfContendedSafely();
     }
 
     @Implements(ContentUris.class)

--- a/demo-extended/src/main/AndroidManifest.xml
+++ b/demo-extended/src/main/AndroidManifest.xml
@@ -2,17 +2,17 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="com.novoda.sqliteprovider.demo"
   android:versionCode="1"
-  android:versionName="1.0" >
+  android:versionName="1.0">
 
   <application
     android:name=".NovodaApplication"
     android:allowBackup="true"
     android:icon="@drawable/ic_launcher"
     android:label="@string/app_name"
-    android:theme="@style/AppTheme" >
+    android:theme="@style/AppTheme">
     <activity
       android:name=".ui.MainActivity"
-      android:label="@string/app_name" >
+      android:label="@string/app_name">
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />
 
@@ -28,6 +28,9 @@
     <activity
       android:name=".ui.AddBulkFireworksActivity"
       android:label="@string/activity_label_add_bulk_fireworks" />
+    <activity
+      android:name=".ui.AddBulkYieldFireworksActivity"
+      android:label="@string/activity_label_add_bulk_yield_fireworks" />
     <activity
       android:name=".ui.FindFireworkWithPkActivity"
       android:label="@string/activity_label_find_firework" />

--- a/demo-extended/src/main/java/com/novoda/sqliteprovider/demo/domain/UseCaseFactory.java
+++ b/demo-extended/src/main/java/com/novoda/sqliteprovider/demo/domain/UseCaseFactory.java
@@ -10,7 +10,7 @@ public final class UseCaseFactory {
     }
 
     public enum UseCase {
-        ADD, BULK_ADD, ONE_TO_MANY, PRIMARY_KEY_LOOKUP, SELECT_ALL, DISTINCT, LIMIT, GROUP_HAVING;
+        ADD, BULK_ADD, BULK_YIELD_ADD, BULK_WIHOUT_YIELD, ONE_TO_MANY, PRIMARY_KEY_LOOKUP, SELECT_ALL, DISTINCT, LIMIT, GROUP_HAVING;
     }
 
     public static UseCaseInfo getInfo(UseCase useCase) {
@@ -19,6 +19,10 @@ public final class UseCaseFactory {
                 return createUseCaseInfo(FireworkUriConstants.ADD_FIREWORK, RawSql.INSERT_FIREWORK);
             case BULK_ADD:
                 return createUseCaseInfo(FireworkUriConstants.ADD_FIREWORK, RawSql.BULK_INSERT_FIREWORKS);
+            case BULK_YIELD_ADD:
+                return createUseCaseInfo(FireworkUriConstants.ADD_FIREWORK_YIELD, RawSql.BULK_INSERT_FIREWORKS);
+            case BULK_WIHOUT_YIELD:
+                return createUseCaseInfo(FireworkUriConstants.ADD_FIREWORK_WITHOUT_YIELD, RawSql.BULK_INSERT_FIREWORKS);
             case ONE_TO_MANY:
                 return createUseCaseInfo(FireworkUriConstants.ONE_TO_MANY_SEARCH, RawSql.SELECT_USING_SHOP_FOREIGN_KEY);
             case PRIMARY_KEY_LOOKUP:

--- a/demo-extended/src/main/java/com/novoda/sqliteprovider/demo/persistance/DatabaseWriter.java
+++ b/demo-extended/src/main/java/com/novoda/sqliteprovider/demo/persistance/DatabaseWriter.java
@@ -20,16 +20,16 @@ public class DatabaseWriter {
     }
 
     public void bulkSaveDataToFireworksTable(ContentValues[] values) {
-        bulkSaveDataToTable(DatabaseConstants.TBL_FIREWORKS, values);
+        bulkSaveDataToTable(DatabaseConstants.TBL_FIREWORKS, values, "true");
     }
 
-    private void bulkSaveDataToTable(String table, ContentValues[] values) {
-        Uri uri = createUriWithoutYieldFor(table);
+    public void bulkSaveDataToFireworksTableWithoutYield(ContentValues[] values) {
+        bulkSaveDataToTable(DatabaseConstants.TBL_FIREWORKS, values, "false");
+    }
+
+    private void bulkSaveDataToTable(String table, ContentValues[] values, String allowYield) {
+        Uri uri = createUri(table).buildUpon().appendQueryParameter(KEY_ALLOW_YIELD, allowYield).build();
         contentResolver.bulkInsert(uri, values);
-    }
-
-    private Uri createUriWithoutYieldFor(String table) {
-        return createUri(table).buildUpon().appendQueryParameter(KEY_ALLOW_YIELD, "false").build();
     }
 
     private void saveDataToTable(String table, ContentValues values) {

--- a/demo-extended/src/main/java/com/novoda/sqliteprovider/demo/persistance/DatabaseWriter.java
+++ b/demo-extended/src/main/java/com/novoda/sqliteprovider/demo/persistance/DatabaseWriter.java
@@ -8,6 +8,7 @@ import com.novoda.sqliteprovider.demo.provider.FireworkProvider;
 
 public class DatabaseWriter {
 
+    private static final String KEY_ALLOW_YIELD = "allowYield";
     private final ContentResolver contentResolver;
 
     public DatabaseWriter(ContentResolver contentResolver) {
@@ -23,8 +24,12 @@ public class DatabaseWriter {
     }
 
     private void bulkSaveDataToTable(String table, ContentValues[] values) {
-        Uri uri = createUri(table);
+        Uri uri = createUriWithoutYieldFor(table);
         contentResolver.bulkInsert(uri, values);
+    }
+
+    private Uri createUriWithoutYieldFor(String table) {
+        return createUri(table).buildUpon().appendQueryParameter(KEY_ALLOW_YIELD, "false").build();
     }
 
     private void saveDataToTable(String table, ContentValues values) {

--- a/demo-extended/src/main/java/com/novoda/sqliteprovider/demo/persistance/FireworkWriter.java
+++ b/demo-extended/src/main/java/com/novoda/sqliteprovider/demo/persistance/FireworkWriter.java
@@ -32,6 +32,16 @@ public class FireworkWriter {
         databaseWriter.bulkSaveDataToFireworksTable(valuesArray.toArray(new ContentValues[fireworks.size()]));
     }
 
+    public void saveFireworksWithoutYield(List<Firework> fireworks) {
+        List<ContentValues> valuesArray = new ArrayList<>();
+        for (Firework firework : fireworks) {
+            ContentValues values = createContentValuesFrom(firework);
+            valuesArray.add(values);
+        }
+
+        databaseWriter.bulkSaveDataToFireworksTableWithoutYield(valuesArray.toArray(new ContentValues[fireworks.size()]));
+    }
+
     private ContentValues createContentValuesFrom(Firework firework) {
         ContentValues values = new ContentValues();
         values.put(COL_NAME, firework.getName());

--- a/demo-extended/src/main/java/com/novoda/sqliteprovider/demo/provider/FireworkUriConstants.java
+++ b/demo-extended/src/main/java/com/novoda/sqliteprovider/demo/provider/FireworkUriConstants.java
@@ -7,6 +7,8 @@ public final class FireworkUriConstants {
 
     public static final String VIEW_ALL_SEARCH = FireworkProvider.AUTHORITY + "firework";
     public static final String ADD_FIREWORK = FireworkProvider.AUTHORITY + "firework (with ContentValues)";
+    public static final String ADD_FIREWORK_YIELD = FireworkProvider.AUTHORITY + "firework?allowYield=true (with ContentValues)";
+    public static final String ADD_FIREWORK_WITHOUT_YIELD = FireworkProvider.AUTHORITY + "firework?allowYield=false (with ContentValues)";
     public static final String PRIMARY_KEY_SEARCH = FireworkProvider.AUTHORITY + "firework/1";
     public static final String ONE_TO_MANY_SEARCH = FireworkProvider.AUTHORITY + "shop/1/firework";
     public static final String GROUP_BY_SEARCH = FireworkProvider.AUTHORITY + "firework?groupBy=shop_id&having=SUM(price)>40";

--- a/demo-extended/src/main/java/com/novoda/sqliteprovider/demo/ui/AddBulkFireworksActivity.java
+++ b/demo-extended/src/main/java/com/novoda/sqliteprovider/demo/ui/AddBulkFireworksActivity.java
@@ -9,7 +9,6 @@ import android.widget.Toast;
 import com.novoda.sqliteprovider.demo.R;
 import com.novoda.sqliteprovider.demo.domain.Firework;
 import com.novoda.sqliteprovider.demo.domain.UseCaseFactory;
-import com.novoda.sqliteprovider.demo.loader.FireworkSaver;
 import com.novoda.sqliteprovider.demo.loader.FireworksBulkSaver;
 import com.novoda.sqliteprovider.demo.persistance.DatabaseConstants;
 import com.novoda.sqliteprovider.demo.ui.base.NovodaActivity;
@@ -40,7 +39,7 @@ public class AddBulkFireworksActivity extends NovodaActivity implements AddBulkF
     @Override
     public void onBulkAddClick(List<Firework> fireworks) {
         this.fireworks = fireworks;
-        getSupportLoaderManager().initLoader(FireworkSaver.LOADER_ID, null, this);
+        getSupportLoaderManager().initLoader(FireworksBulkSaver.LOADER_ID, null, this);
     }
 
     @Override

--- a/demo-extended/src/main/java/com/novoda/sqliteprovider/demo/ui/AddBulkYieldFireworksActivity.java
+++ b/demo-extended/src/main/java/com/novoda/sqliteprovider/demo/ui/AddBulkYieldFireworksActivity.java
@@ -1,0 +1,79 @@
+package com.novoda.sqliteprovider.demo.ui;
+
+import android.os.AsyncTask;
+import android.os.Build;
+import android.os.Bundle;
+import android.text.TextUtils;
+import android.widget.Toast;
+
+import com.novoda.sqliteprovider.demo.R;
+import com.novoda.sqliteprovider.demo.domain.Firework;
+import com.novoda.sqliteprovider.demo.domain.UseCaseFactory;
+import com.novoda.sqliteprovider.demo.persistance.DatabaseConstants;
+import com.novoda.sqliteprovider.demo.persistance.DatabaseWriter;
+import com.novoda.sqliteprovider.demo.persistance.FireworkWriter;
+import com.novoda.sqliteprovider.demo.ui.base.NovodaActivity;
+import com.novoda.sqliteprovider.demo.ui.fragment.AddBulkYieldFireworksFragment;
+import com.novoda.sqliteprovider.demo.ui.fragment.UriSqlFragment;
+
+import java.util.List;
+
+public class AddBulkYieldFireworksActivity extends NovodaActivity implements AddBulkYieldFireworksFragment.AddBulkYieldFireworksListener, FireworksWriteTask.Listener {
+
+    private UriSqlFragment uriSqlFragment;
+    private List<Firework> fireworks;
+    private FireworkWriter writer;
+    private AddBulkYieldFireworksFragment bulkInsertFragment;
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_add_bulk_yield_fireworks);
+        DatabaseWriter databaseWriter = new DatabaseWriter(getContentResolver());
+        writer = new FireworkWriter(databaseWriter);
+        uriSqlFragment = (UriSqlFragment) getSupportFragmentManager().findFragmentById(R.id.fragment_uri_sql);
+        bulkInsertFragment = (AddBulkYieldFireworksFragment) getSupportFragmentManager().findFragmentById(R.id.fragment_add_bulk_yield_fireworks);
+    }
+
+    @Override
+    public void onEmptyInput() {
+        Toast.makeText(this, "Fill in the number of fireworks and threads!", Toast.LENGTH_SHORT).show();
+    }
+
+    @Override
+    public void onBulkAddClick(List<Firework> fireworks, int numberOfThreads, boolean shouldYield) {
+        this.fireworks = fireworks;
+        Firework[] fireworksArray = fireworks.toArray(new Firework[fireworks.size()]);
+        for (int i = 0; i < numberOfThreads; i++) {
+            String name = "Thread - " + i + " items: " + fireworks.size() + " - allowYield: " + shouldYield;
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+                new FireworksWriteTask(name, writer, shouldYield, this).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, fireworksArray);
+            } else {
+                new FireworksWriteTask(name, writer, shouldYield, this).execute(fireworksArray);
+            }
+        }
+        uriSqlFragment.setInfo(shouldYield ? UseCaseFactory.UseCase.BULK_YIELD_ADD : UseCaseFactory.UseCase.BULK_WIHOUT_YIELD);
+    }
+
+    private String createSQL(List<Firework> data) {
+        Firework firework = data.get(0);
+        return TextUtils.replace(
+                DatabaseConstants.RawSql.BULK_INSERT_FIREWORKS,
+                new String[]{"Times", "Na", "Co", "No", "Ft", "Pr", "Sh"},
+                new CharSequence[]{
+                        String.valueOf(data.size()),
+                        firework.getName(),
+                        firework.getColor(),
+                        firework.getNoise(),
+                        firework.getType(),
+                        String.valueOf(firework.getPrice()), "1"
+                }).toString();
+    }
+
+    @Override
+    public void onFinish(String name, long duration) {
+        uriSqlFragment.updateSql(createSQL(fireworks));
+        String text = "Finished: " + name + " - took: " + duration + " millis";
+        bulkInsertFragment.appendLog(text);
+    }
+}

--- a/demo-extended/src/main/java/com/novoda/sqliteprovider/demo/ui/FireworksWriteTask.java
+++ b/demo-extended/src/main/java/com/novoda/sqliteprovider/demo/ui/FireworksWriteTask.java
@@ -1,0 +1,51 @@
+package com.novoda.sqliteprovider.demo.ui;
+
+import android.os.AsyncTask;
+
+import com.novoda.sqliteprovider.demo.domain.Firework;
+import com.novoda.sqliteprovider.demo.persistance.FireworkWriter;
+
+import java.util.Arrays;
+import java.util.List;
+
+class FireworksWriteTask extends AsyncTask<Firework, Void, Void> {
+
+    private final String name;
+    private final FireworkWriter writer;
+    private final boolean allowYield;
+    private final Listener listener;
+
+    private long startTime;
+
+    FireworksWriteTask(String name, FireworkWriter writer, boolean allowYield, Listener listener) {
+        this.name = name;
+        this.writer = writer;
+        this.allowYield = allowYield;
+        this.listener = listener;
+    }
+
+    @Override
+    protected void onPreExecute() {
+        startTime = System.currentTimeMillis();
+    }
+
+    @Override
+    protected Void doInBackground(Firework... params) {
+        List<Firework> fireworks = Arrays.asList(params);
+        if (allowYield) {
+            writer.saveFireworks(fireworks);
+        } else {
+            writer.saveFireworksWithoutYield(fireworks);
+        }
+        return null;
+    }
+
+    @Override
+    protected void onPostExecute(Void fireworks) {
+        listener.onFinish(name, System.currentTimeMillis() - startTime);
+    }
+
+    interface Listener {
+        void onFinish(String name, long duration);
+    }
+}

--- a/demo-extended/src/main/java/com/novoda/sqliteprovider/demo/ui/MainActivity.java
+++ b/demo-extended/src/main/java/com/novoda/sqliteprovider/demo/ui/MainActivity.java
@@ -38,6 +38,12 @@ public class MainActivity extends NovodaActivity implements DemoMenu {
 
     @Override
     @FromXML
+    public void onBulkAddYieldFireworksClick(View view) {
+        startActivity(AddBulkYieldFireworksActivity.class);
+    }
+
+    @Override
+    @FromXML
     public void onFindFireworkWithPrimaryKeyClick(View button) {
         startActivity(FindFireworkWithPkActivity.class);
     }

--- a/demo-extended/src/main/java/com/novoda/sqliteprovider/demo/ui/fragment/AddBulkYieldFireworksFragment.java
+++ b/demo-extended/src/main/java/com/novoda/sqliteprovider/demo/ui/fragment/AddBulkYieldFireworksFragment.java
@@ -1,0 +1,98 @@
+package com.novoda.sqliteprovider.demo.ui.fragment;
+
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v4.app.Fragment;
+import android.text.TextUtils;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.CheckBox;
+import android.widget.EditText;
+import android.widget.TextView;
+
+import com.novoda.sqliteprovider.demo.R;
+import com.novoda.sqliteprovider.demo.domain.Firework;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class AddBulkYieldFireworksFragment extends Fragment {
+
+    private EditText fireworksNumberEditText;
+    private EditText numberOfThreads;
+    private CheckBox allowYield;
+    private TextView resultLogs;
+
+    @Nullable
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        View root = inflater.inflate(R.layout.fragment_add_bulk_yield_fireworks, container, false);
+
+        fireworksNumberEditText = (EditText) root.findViewById(R.id.add_bulk_yield_fireworks_number);
+        numberOfThreads = (EditText) root.findViewById(R.id.add_bulk_yield_fireworks_threads);
+        allowYield = (CheckBox) root.findViewById(R.id.add_bulk_yield_fireworks_yield);
+        resultLogs = (TextView) root.findViewById(R.id.add_bulk_yield_logs);
+        root.findViewById(R.id.add_bulk_yield_fireworks_add_button).setOnClickListener(onAddBulkFireworksClick);
+        return root;
+    }
+
+    private final View.OnClickListener onAddBulkFireworksClick = new View.OnClickListener() {
+        @Override
+        public void onClick(View v) {
+            onAddBulkFireworksClick();
+        }
+    };
+
+    private void onAddBulkFireworksClick() {
+        if (fieldsArentFilledIn()) {
+            notifyActivityEmptyFields();
+            return;
+        }
+
+        int numberOfFireworks = Integer.valueOf(fireworksNumberEditText.getText().toString());
+        List<Firework> fireworks = new ArrayList<>();
+        for (int i = 0; i < numberOfFireworks; i++) {
+            Firework firework = new Firework("BulkYieldFirework" + i, "blue", "bulk", "bang", 99.9);
+            fireworks.add(firework);
+        }
+        notifyActivityFireworksClicked(fireworks);
+    }
+
+    private void notifyActivityFireworksClicked(List<Firework> fireworks) {
+        if (getActivity() instanceof AddBulkYieldFireworksListener) {
+            ((AddBulkYieldFireworksListener) getActivity()).onBulkAddClick(
+                    fireworks,
+                    Integer.valueOf(numberOfThreads.getText().toString()),
+                    allowYield.isChecked()
+            );
+        }
+    }
+
+    private void notifyActivityEmptyFields() {
+        if (getActivity() instanceof AddBulkYieldFireworksListener) {
+            ((AddBulkYieldFireworksListener) getActivity()).onEmptyInput();
+        }
+    }
+
+    private boolean fieldsArentFilledIn() {
+        return isIncorrectInput(fireworksNumberEditText) || isIncorrectInput(numberOfThreads);
+    }
+
+    private boolean isIncorrectInput(EditText editText) {
+        return TextUtils.isEmpty(editText.getText()) || Integer.valueOf(editText.getText().toString()) == 0;
+    }
+
+    public void appendLog(String logs) {
+        CharSequence oldLogs = resultLogs.getText();
+        String text = oldLogs + "\n" + logs;
+        resultLogs.setText(text);
+    }
+
+    public interface AddBulkYieldFireworksListener {
+        void onEmptyInput();
+
+        void onBulkAddClick(List<Firework> fireworks, int numberOfThreads, boolean shouldYield);
+    }
+
+}

--- a/demo-extended/src/main/java/com/novoda/sqliteprovider/demo/ui/input/DemoMenu.java
+++ b/demo-extended/src/main/java/com/novoda/sqliteprovider/demo/ui/input/DemoMenu.java
@@ -20,4 +20,6 @@ public interface DemoMenu {
 
     void onFindUniqueFireworksClick(View button);
 
+    void onBulkAddYieldFireworksClick(View button);
+
 }

--- a/demo-extended/src/main/res/layout/activity_add_bulk_yield_fireworks.xml
+++ b/demo-extended/src/main/res/layout/activity_add_bulk_yield_fireworks.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+  style="@style/match_w_wrap_h">
+
+  <LinearLayout
+    style="@style/match_w_wrap_h"
+    android:orientation="vertical">
+
+    <fragment
+      android:id="@+id/fragment_uri_sql"
+      style="@style/wrap_w_wrap_h"
+      class="com.novoda.sqliteprovider.demo.ui.fragment.UriSqlFragment" />
+
+    <fragment
+      android:id="@+id/fragment_add_bulk_yield_fireworks"
+      style="@style/match_w_wrap_h"
+      class="com.novoda.sqliteprovider.demo.ui.fragment.AddBulkYieldFireworksFragment" />
+  </LinearLayout>
+
+</ScrollView>

--- a/demo-extended/src/main/res/layout/activity_main.xml
+++ b/demo-extended/src/main/res/layout/activity_main.xml
@@ -1,9 +1,9 @@
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-  style="@style/wrap_w_wrap_h" >
+  style="@style/wrap_w_wrap_h">
 
   <LinearLayout
     style="@style/match_w_wrap_h"
-    android:orientation="vertical" >
+    android:orientation="vertical">
 
     <Button
       style="@style/match_w_wrap_h"
@@ -22,6 +22,12 @@
       android:layout_margin="@dimen/norm_spacing"
       android:onClick="onBulkAddFireworksClick"
       android:text="@string/button_main_bulk_add_fireworks" />
+
+    <Button
+      style="@style/match_w_wrap_h"
+      android:layout_margin="@dimen/norm_spacing"
+      android:onClick="onBulkAddYieldFireworksClick"
+      android:text="@string/button_main_bulk_add_yield_fireworks" />
 
     <Button
       style="@style/match_w_wrap_h"

--- a/demo-extended/src/main/res/layout/fragment_add_bulk_yield_fireworks.xml
+++ b/demo-extended/src/main/res/layout/fragment_add_bulk_yield_fireworks.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  android:orientation="vertical"
+  android:layout_width="match_parent"
+  android:layout_height="wrap_content">
+
+  <TextView
+    style="@style/wrap_w_wrap_h"
+    android:padding="@dimen/norm_spacing"
+    android:text="@string/activity_add_bulk_fireworks_text" />
+
+  <EditText
+    android:id="@+id/add_bulk_yield_fireworks_number"
+    style="@style/match_w_wrap_h"
+    android:layout_margin="@dimen/norm_spacing"
+    android:hint="@string/activity_add_bulk_fireworks_input_number"
+    android:imeOptions="actionNext"
+    android:inputType="number"
+    android:maxLines="1" />
+
+  <EditText
+    android:id="@+id/add_bulk_yield_fireworks_threads"
+    style="@style/match_w_wrap_h"
+    android:layout_margin="@dimen/norm_spacing"
+    android:hint="@string/activity_add_bulk_yield_fireworks_threads"
+    android:imeOptions="actionNext"
+    android:inputType="number"
+    android:maxLines="1" />
+
+  <CheckBox
+    android:id="@+id/add_bulk_yield_fireworks_yield"
+    android:checked="true"
+    android:text="@string/allow_yield"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content" />
+
+  <Button
+    android:id="@+id/add_bulk_yield_fireworks_add_button"
+    style="@style/match_w_wrap_h"
+    android:layout_margin="@dimen/norm_spacing"
+    android:hint="@string/button_add_fireworks" />
+
+  <TextView
+    android:id="@+id/add_bulk_yield_logs"
+    style="@style/match_w_wrap_h" />
+
+</LinearLayout>

--- a/demo-extended/src/main/res/values/strings.xml
+++ b/demo-extended/src/main/res/values/strings.xml
@@ -5,6 +5,7 @@
   <string name="button_main_view_all_fireworks">View all Fireworks</string>
   <string name="button_main_add_firework">Add a new Firework</string>
   <string name="button_main_bulk_add_fireworks">Add bulk Fireworks</string>
+  <string name="button_main_bulk_add_yield_fireworks">Add bulk Yield Fireworks</string>
   <string name="activity_add_firework_text">Add a firework to the firework table in your database</string>
   <string name="activity_add_firework_input_title_name">Name:</string>
   <string name="activity_add_firework_input_title_color">Color:</string>
@@ -29,6 +30,7 @@
   <string name="activity_label_all_fireworks">All Fireworks</string>
   <string name="activity_label_add_new_firework">Add New Firework</string>
   <string name="activity_label_add_bulk_fireworks">Add bulk Fireworks</string>
+  <string name="activity_label_add_bulk_yield_fireworks">Add bulk yield Fireworks</string>
   <string name="activity_label_find_firework">Find Firework</string>
   <string name="activity_find_firework_with_pk_firework_primary_key_input_title">Firework Primary Key:</string>
   <string name="activity_find_firework_with_pk_firework_primary_key_input_hint">Primary Key</string>
@@ -43,5 +45,7 @@
   <string name="activity_label_find_firework_from_shop">Find Fireworks with shop PK</string>
   <string name="activity_add_bulk_fireworks_text">Bulk add random fireworks in the firework table</string>
   <string name="activity_add_bulk_fireworks_input_number">Number of random fireworks</string>
+  <string name="activity_add_bulk_yield_fireworks_threads">Number of parallel threads</string>
+  <string name="allow_yield">Allow yield</string>
 
 </resources>


### PR DESCRIPTION
Allowing to specify an optional query parameter for allowing or not [`yieldIfContendedSafely()`](http://developer.android.com/reference/android/database/sqlite/SQLiteDatabase.html#yieldIfContendedSafely()) during bulk inserts. 

The reasoning behind not wanting the yield is that in case of parallel multithreaded bulkInserts the yield will case ending and starting new transactions and thread context switching in turn causing performance issues. 

In order to keep backwards compatibility and for a more flexible API, we didn't removed the yield completely, but rather let the user choose. By default, the bulkInsert **will** yield. 

_Notice the major increase of performance when not using yield_:

![bluk_yield](https://cloud.githubusercontent.com/assets/913571/7940989/3558cca0-094c-11e5-95bb-63c8f4732def.png)
