### PR TITLE
Updating the README for updating from old versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ dependencies {
 }
 ```
 
+## Upgrading from < 1.0.4
+
+Please note the name change from `sqliteprovider-core` to `sqlite-provider` when the version went beyond 1.0.4 (all the way back in 2014!). If you're upgrading from a version that old, don't forget to change the name too!
+
 
 ## Simple usage
 


### PR DESCRIPTION
### Problem

We were on 1.0.4 and not seeing any newer version because the name changed from sqliteprovider-core to sqliteprovider. Then when I came here and saw the latest version was 1.2.0 I just tried changing the number and was wondering why it didn't work.

### Solution

Just adding a little note to the README to draw attention to that name change, in the case that anyone is upgrading from a super old version (1.0.4).