### PR TITLE
Bug / Integer primary key conflict should upsert

### DIFF
--- a/core/src/androidTest/assets/migrations/129467607_create.sql
+++ b/core/src/androidTest/assets/migrations/129467607_create.sql
@@ -1,2 +1,4 @@
 CREATE TABLE 'parents' (_id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT UNIQUE, description TEXT, latitude REAL, longitude REAL, createdAt INTEGER);
 CREATE TABLE 'childs' (_id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, parent_id INTEGER NOT NULL, FOREIGN KEY(parent_id) REFERENCES parent(_id));
+-- This table intentionally has no Foreign Keys, no UNIQUE fields, no indexes, apart from the implicit index from the INTEGER PRIMARY KEY.
+CREATE TABLE 'integer_primary_key_table' (_id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT);

--- a/core/src/androidTest/java/novoda/lib/sqliteprovider/sqlite/InsertHelperTest.java
+++ b/core/src/androidTest/java/novoda/lib/sqliteprovider/sqlite/InsertHelperTest.java
@@ -9,6 +9,22 @@ import novoda.lib.sqliteprovider.provider.action.InsertHelper;
 
 public class InsertHelperTest extends AndroidTestCase {
 
+    private static final String A_NAME_VALUE = "a name";
+    private static final String A_DESCRIPTION_VALUE = "a description";
+    private static final String DIFFERENT_DESCRIPTION_VALUE = "a different description";
+    private static final String ID_COLUMN = "_id";
+
+    private class ParentsColumns {
+        static final String ID = ID_COLUMN;
+        static final String NAME = "name";
+        static final String DESCRIPTION = "description";
+    }
+
+    private static final String PARENTS_TABLE = "parents";
+
+    private static final String BASE_URI_STRING = "content://novoda.lib.sqliteprovider.test/";
+    private static final Uri PARENTS_URI = Uri.parse(BASE_URI_STRING + PARENTS_TABLE);
+
     private InsertHelper helper;
     private ExtendedSQLiteOpenHelper openHelper;
 
@@ -17,26 +33,85 @@ public class InsertHelperTest extends AndroidTestCase {
         super.setUp();
         openHelper = new ExtendedSQLiteOpenHelper(getContext());
         helper = new InsertHelper(openHelper);
+
+        clearParentsTable();
     }
 
-    public void testInsertWithKeyShouldInsertThenUpdate() throws Exception {
-        Uri uri = Uri.parse("content://novoda.lib.sqliteprovider.test/parents");
-        ContentValues values = new ContentValues();
-        values.put("name", "something unique");
-        values.put("description", "something");
-        helper.insert(uri, values);
+    public void testInsertWithNoConflictShouldInsert() {
+        helper.insert(PARENTS_URI, parentsContentValues(A_NAME_VALUE, A_DESCRIPTION_VALUE));
 
-        Cursor cursor = openHelper.getReadableDatabase().rawQuery("select * from parents", null);
-        assertEquals(1, cursor.getCount());
-        cursor.close();
+        onQueryOf(PARENTS_TABLE, new CursorOperations() {
+            @Override
+            public void doOperationsOn(Cursor cursor) {
+                assertEquals(1, cursor.getCount());
+                assertEquals(A_NAME_VALUE, stringFrom(cursor, ParentsColumns.NAME));
+                assertEquals(A_DESCRIPTION_VALUE, stringFrom(cursor, ParentsColumns.DESCRIPTION));
+            }
+        });
+    }
 
-        values.put("description", "else");
-        helper.insert(uri, values);
+    public void testInsertWithUniqueColumnConflictShouldUpdate() {
+        helper.insert(PARENTS_URI, parentsContentValues(A_NAME_VALUE, A_DESCRIPTION_VALUE));
+        final int existingRowId = idOfFirstRowIn(queryOf(PARENTS_TABLE));
 
-        cursor = openHelper.getReadableDatabase().rawQuery("select * from parents", null);
-        assertEquals(1, cursor.getCount());
+        helper.insert(PARENTS_URI, parentsContentValues(A_NAME_VALUE, DIFFERENT_DESCRIPTION_VALUE));
+
+        onQueryOf(PARENTS_TABLE, new CursorOperations() {
+            @Override
+            public void doOperationsOn(Cursor cursor) {
+                assertEquals(1, cursor.getCount());
+                assertEquals(existingRowId, intFrom(cursor, ParentsColumns.ID));
+                assertEquals(A_NAME_VALUE, stringFrom(cursor, ParentsColumns.NAME));
+                assertEquals(DIFFERENT_DESCRIPTION_VALUE, stringFrom(cursor, ParentsColumns.DESCRIPTION));
+            }
+        });
+    }
+
+
+    private String stringFrom(Cursor cursor, String columnName) {
+        return cursor.getString(cursor.getColumnIndex(columnName));
+    }
+
+    private int intFrom(Cursor cursor, String columnName) {
+        return cursor.getInt(cursor.getColumnIndex(columnName));
+    }
+
+    private int idOfFirstRowIn(Cursor cursor) {
+        try {
+            assertTrue("No rows in table!", cursor.getCount() > 0);
+            cursor.moveToFirst();
+            return intFrom(cursor, ID_COLUMN);
+        } finally {
+            cursor.close();
+        }
+    }
+
+    private void clearParentsTable() {
+        openHelper.getWritableDatabase().delete(PARENTS_TABLE, null, null);
+    }
+
+    private ContentValues parentsContentValues(String name, String description) {
+        ContentValues contentValues = new ContentValues();
+        contentValues.put(ParentsColumns.NAME, name);
+        contentValues.put(ParentsColumns.DESCRIPTION, description);
+        return contentValues;
+    }
+
+    private Cursor queryOf(String tableName) {
+        return openHelper.getReadableDatabase().rawQuery("select * from " + tableName, null);
+    }
+
+    private void onQueryOf(String tableName, CursorOperations cursorOperations) {
+        Cursor cursor = queryOf(tableName);
         cursor.moveToFirst();
-        assertEquals("else", cursor.getString(cursor.getColumnIndex("description")));
+        try {
+            cursorOperations.doOperationsOn(cursor);
+        } finally {
+            cursor.close();
+        }
+    }
 
+    private static interface CursorOperations {
+        void doOperationsOn(Cursor cursor);
     }
 }

--- a/core/src/androidTest/java/novoda/lib/sqliteprovider/util/DBUtilsTest.java
+++ b/core/src/androidTest/java/novoda/lib/sqliteprovider/util/DBUtilsTest.java
@@ -19,6 +19,7 @@ public class DBUtilsTest extends AndroidTestCase {
     private static final String CREATE_2_TABLES_WITH_FOREIGN_KEY = "CREATE TABLE t(id INTEGER);\nCREATE TABLE t2(id INTEGER, t_id INTEGER);\n";
     private static final String CREATE_TABLE_WITH_CONSTRAINT = "CREATE TABLE t(id INTEGER, const TEXT UNIQUE NOT NULL);";
     private static final String CREATE_TABLE_WITH_MULTI_COLUMN_CONSTRAINT = "CREATE TABLE t(id INTEGER, name TEXT, desc TEXT NOT NULL, UNIQUE(name, desc) ON CONFLICT REPLACE);";
+    private static final String CREATE_TABLE_WITH_INTEGER_PRIMARY_KEY = "CREATE TABLE t(_id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT);";
 
     @Override
     protected void setUp() throws Exception {
@@ -69,6 +70,14 @@ public class DBUtilsTest extends AndroidTestCase {
         SQLiteDatabase db = getContext().openOrCreateDatabase(DB_NAME, 0, null);
         List<Constraint> constrains = DBUtils.getUniqueConstraints(db, "t");
         MoreAsserts.assertContentsInAnyOrder(constrains, new Constraint(Arrays.asList("const")));
+    }
+
+    public void testGettingUniqueConstraintForIntegerPrimaryKey() throws Exception {
+        android.database.DatabaseUtils.createDbFromSqlStatements(getContext(), DB_NAME, 1, CREATE_TABLE_WITH_INTEGER_PRIMARY_KEY);
+
+        SQLiteDatabase db = getContext().openOrCreateDatabase(DB_NAME, 0, null);
+        List<Constraint> constrains = DBUtils.getUniqueConstraints(db, "t");
+        MoreAsserts.assertContentsInAnyOrder(constrains, new Constraint(Arrays.asList("_id")));
     }
 
     public void testGettingMultiColumnUniqueConstraints() throws Exception {

--- a/core/src/androidTest/java/novoda/lib/sqliteprovider/util/DBUtilsTest.java
+++ b/core/src/androidTest/java/novoda/lib/sqliteprovider/util/DBUtilsTest.java
@@ -68,30 +68,30 @@ public class DBUtilsTest extends AndroidTestCase {
         android.database.DatabaseUtils.createDbFromSqlStatements(getContext(), DB_NAME, 1, CREATE_TABLE_WITH_CONSTRAINT);
 
         SQLiteDatabase db = getContext().openOrCreateDatabase(DB_NAME, 0, null);
-        List<Constraint> constrains = DBUtils.getUniqueConstraints(db, "t");
-        MoreAsserts.assertContentsInAnyOrder(constrains, new Constraint(Arrays.asList("const")));
+        List<Constraint> constraints = DBUtils.getUniqueConstraints(db, "t");
+        MoreAsserts.assertContentsInAnyOrder(constraints, new Constraint(Arrays.asList("const")));
     }
 
     public void testGettingUniqueConstraintForIntegerPrimaryKey() throws Exception {
         android.database.DatabaseUtils.createDbFromSqlStatements(getContext(), DB_NAME, 1, CREATE_TABLE_WITH_INTEGER_PRIMARY_KEY);
 
         SQLiteDatabase db = getContext().openOrCreateDatabase(DB_NAME, 0, null);
-        List<Constraint> constrains = DBUtils.getUniqueConstraints(db, "t");
-        MoreAsserts.assertContentsInAnyOrder(constrains, new Constraint(Arrays.asList("_id")));
+        List<Constraint> constraints = DBUtils.getUniqueConstraints(db, "t");
+        MoreAsserts.assertContentsInAnyOrder(constraints, new Constraint(Arrays.asList("_id")));
     }
 
     public void testGettingMultiColumnUniqueConstraints() throws Exception {
         android.database.DatabaseUtils.createDbFromSqlStatements(getContext(), DB_NAME, 1, CREATE_TABLE_WITH_MULTI_COLUMN_CONSTRAINT);
 
         SQLiteDatabase db = getContext().openOrCreateDatabase(DB_NAME, 0, null);
-        List<Constraint> constrains = DBUtils.getUniqueConstraints(db, "t");
-        MoreAsserts.assertContentsInAnyOrder(constrains, new Constraint(Arrays.asList("name", "desc")));
+        List<Constraint> constraints = DBUtils.getUniqueConstraints(db, "t");
+        MoreAsserts.assertContentsInAnyOrder(constraints, new Constraint(Arrays.asList("name", "desc")));
     }
 
     public void testGettingUniqueConstraintsIsEmpty() throws Exception {
         android.database.DatabaseUtils.createDbFromSqlStatements(getContext(), DB_NAME, 1, CREATE_TABLES);
         SQLiteDatabase db = getContext().openOrCreateDatabase(DB_NAME, 0, null);
-        List<Constraint> constrains = DBUtils.getUniqueConstraints(db, "t");
-        MoreAsserts.assertEmpty(constrains);
+        List<Constraint> constraints = DBUtils.getUniqueConstraints(db, "t");
+        MoreAsserts.assertEmpty(constraints);
     }
 }

--- a/core/src/main/java/novoda/lib/sqliteprovider/sqlite/IDatabaseMetaInfo.java
+++ b/core/src/main/java/novoda/lib/sqliteprovider/sqlite/IDatabaseMetaInfo.java
@@ -12,6 +12,10 @@ public interface IDatabaseMetaInfo {
 
     public enum SQLiteType {
         NULL, INTEGER, REAL, TEXT, BLOB, NUMERIC;
+
+        public static SQLiteType fromName(String columnType) {
+            return valueOf(columnType.toUpperCase());
+        }
     }
     Map<String, SQLiteType> getColumns(String table);
 

--- a/core/src/main/java/novoda/lib/sqliteprovider/util/DBUtils.java
+++ b/core/src/main/java/novoda/lib/sqliteprovider/util/DBUtils.java
@@ -45,7 +45,7 @@ public final class DBUtils {
         String name;
         String tableName;
         while (cur.moveToNext()) {
-            name = cur.getString(cur.getColumnIndexOrThrow("name"));
+            name = cur.getString(cur.getColumnIndexOrThrow(COLUMN_NAME));
             if (name.endsWith("_id")) {
                 tableName = name.substring(0, name.lastIndexOf('_'));
                 if (tables.contains(tableName + "s")) {
@@ -100,8 +100,8 @@ public final class DBUtils {
         String name;
         String type;
         while (cursor.moveToNext()) {
-            name = cursor.getString(cursor.getColumnIndexOrThrow("name"));
-            type = cursor.getString(cursor.getColumnIndexOrThrow("type"));
+            name = cursor.getString(cursor.getColumnIndexOrThrow(COLUMN_NAME));
+            type = cursor.getString(cursor.getColumnIndexOrThrow(COLUMN_TYPE));
             fields.put(name, SQLiteType.fromName(type));
         }
         cursor.close();

--- a/core/src/main/java/novoda/lib/sqliteprovider/util/DBUtils.java
+++ b/core/src/main/java/novoda/lib/sqliteprovider/util/DBUtils.java
@@ -180,7 +180,7 @@ public final class DBUtils {
         final Cursor cursor = queryTableColumnsFor(table, database);
         try {
             while (cursor.moveToNext()) {
-                if (isCurrentColumnAnIntegerPrimaryKey(cursor)) {
+                if (isTableInfoItemAnIntegerPrimaryKey(cursor)) {
                     String columnName = cursor.getString(cursor.getColumnIndex(COLUMN_NAME));
                     return new Constraint(Collections.singletonList(columnName));
                 }
@@ -203,7 +203,7 @@ public final class DBUtils {
         return database.rawQuery(String.format(PRGAMA_INDEX_INFO, index), null);
     }
 
-    private static boolean isCurrentColumnAnIntegerPrimaryKey(Cursor cursor) {
+    private static boolean isTableInfoItemAnIntegerPrimaryKey(Cursor cursor) {
         int pkInt = cursor.getInt(cursor.getColumnIndex(COLUMN_PRIMARY_KEY));
         String columnType = cursor.getString(cursor.getColumnIndex(COLUMN_TYPE));
 

--- a/core/src/main/java/novoda/lib/sqliteprovider/util/DBUtils.java
+++ b/core/src/main/java/novoda/lib/sqliteprovider/util/DBUtils.java
@@ -207,7 +207,8 @@ public final class DBUtils {
         int pkInt = cursor.getInt(cursor.getColumnIndex(COLUMN_PRIMARY_KEY));
         String columnType = cursor.getString(cursor.getColumnIndex(COLUMN_TYPE));
 
-        boolean isPrimaryKey = pkInt == 1;
+        // NOT A BOOLEAN AS INTEGER: 0 if not part of PK, otherwise index of column in key: https://www.sqlite.org/pragma.html#pragma_table_info
+        boolean isPrimaryKey = pkInt != 0;
         boolean isInteger = SQLiteType.fromName(columnType) == SQLiteType.INTEGER;
 
         return isPrimaryKey && isInteger;


### PR DESCRIPTION
#### Problem

InsertHelper claims it will perform an "upsert" - that is, update if present, insert if not - but this only works for tables with explicitly defined uniqueness constraints that will result in explicit indexes.

There is a common pattern of usage with SQLite to use a synthetic primary key column named `_id`, and for that column to be declared as an `INTEGER PRIMARY KEY`. As per the [`SQLite docs`](https://www.sqlite.org/autoinc.html):

> If a table contains a column of type INTEGER PRIMARY KEY, then that column becomes an alias for the ROWID

When this happens, there will not be an explicit unique index created for this column. None is needed; it is an alias for the `ROWID`, which is inherently unique and faster than any index. In the case that this is the only thing constrained to be unique in a table, the library fails to detect this constraint and thus does not switch to an update. It instead attempts an insert, which fails.

#### Solution

Functionality has been added to DbUtils to detect an `INTEGER PRIMARY KEY` on a table, and if found, to add this to the list of constraints it will find for a table. With the implicit constraint made apparent, the library performs correctly.

#### Tests

 * A test has been added for DbUtils to verify that it will now include a constraint of this type if present.
 * The one existing test for InsertHelper that was testing two things has been split into two, and some efforts made to increase readability. It's rather tricky to verify things with a cursor in a readable way, without some other testing library, but I've settled on something that I think works and keeps it quite simple (i.e. not so complicated the tests would need tests!). This especially benefits from IDE collapsing of Java boilerplate, though I don't think it's too bad without.
 * One more test has then been added for InsertHelper to verify this specific case of "upsert". The unfortunate widespread usage of static functions makes decoupling tests on InsertHelper from also relying on DbUtils impossible, and the goal here isn't to restructure the architecture of the library, so this is left as is for now.
