### PR TITLE
Update version no. for release v1.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.novoda:sqlite-provider:1.2.0'
+    compile 'com.novoda:sqlite-provider:1.2.1'
 }
 ```
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -35,7 +35,7 @@ publish {
     userOrg = 'novoda'
     groupId = 'com.novoda'
     artifactId = 'sqlite-provider'
-    version = '1.2.0'
+    version = '1.2.1'
     description = 'Extended SQLite functionality for Android'
     website = 'https://github.com/novoda/sqlite-provider'
 }


### PR DESCRIPTION
Just updating the version number so the fix in [this 'integer primary key' bug fix](https://github.com/novoda/sqlite-provider/pull/60) can go out.

So far as I can see this is all that's needed before kicking off a build on CI. Please correct me if I've missed something.