### PR TITLE
Fix update behaviour in content provider implementation

### DIFF
--- a/core/src/androidTest/java/novoda/lib/sqliteprovider/ContentProviderTest.java
+++ b/core/src/androidTest/java/novoda/lib/sqliteprovider/ContentProviderTest.java
@@ -1,11 +1,21 @@
 
 package novoda.lib.sqliteprovider;
 
+import android.content.ContentValues;
 import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
 import android.net.Uri;
 import android.test.AndroidTestCase;
 
+import java.io.IOException;
+
+import novoda.lib.sqliteprovider.sqlite.ExtendedSQLiteOpenHelper;
+
 public class ContentProviderTest extends AndroidTestCase {
+
+    private static final String TABLE_NAME = "test";
+    private static final String COLUMN_PRIMARY_KEY = "column_primary_key";
+    private static final String COLUMN2 = "column2";
 
     public ContentProviderTest() {
         super();
@@ -17,5 +27,47 @@ public class ContentProviderTest extends AndroidTestCase {
                 null, null, null);
         assertTrue(cursor.getColumnIndexOrThrow("childs__id") > -1);
         assertTrue(cursor.getColumnIndexOrThrow("parents_name") > -1);
+    }
+
+    public void test_GivenATableWithData_When_UpdatingNonexistentRow_Then_NumberOfAffectedRowsShouldBeZero() throws Exception {
+        givenATableWithData();
+
+        ContentValues values = new ContentValues(1);
+        values.put(COLUMN2, 1);
+
+        int numRows = new ExtendedSQLiteOpenHelper(getContext())
+                .getWritableDatabase()
+                .update(TABLE_NAME, values, COLUMN_PRIMARY_KEY + "=?", new String[]{"2"});
+
+        assertEquals(0, numRows);
+
+        numRows = getContext().getContentResolver().update(
+                Uri.parse("content://novoda.lib.sqliteprovider.test/" + TABLE_NAME),
+                values,
+                COLUMN_PRIMARY_KEY + "=?",
+                new String[]{"2"});
+
+        assertEquals(0, numRows);
+    }
+
+    private void givenATableWithData() throws IOException {
+        ExtendedSQLiteOpenHelper helper = new ExtendedSQLiteOpenHelper(getContext());
+        SQLiteDatabase db = helper.getWritableDatabase();
+        db.execSQL("CREATE TABLE IF NOT EXISTS `" + TABLE_NAME + "` (" +
+                           "`" + COLUMN_PRIMARY_KEY + "` INTEGER PRIMARY KEY," +
+                           "`" + COLUMN2 + "` INTEGER UNIQUE)");
+
+        ContentValues values = new ContentValues(2);
+        values.put(COLUMN_PRIMARY_KEY, 1);
+        values.put(COLUMN2, 1);
+        helper.getWritableDatabase().insert(TABLE_NAME, null, values);
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        super.tearDown();
+        ExtendedSQLiteOpenHelper helper = new ExtendedSQLiteOpenHelper(getContext());
+        SQLiteDatabase db = helper.getWritableDatabase();
+        db.execSQL("DROP TABLE IF EXISTS `" + TABLE_NAME + "`");
     }
 }

--- a/core/src/androidTest/java/novoda/lib/sqliteprovider/ContentProviderTest.java
+++ b/core/src/androidTest/java/novoda/lib/sqliteprovider/ContentProviderTest.java
@@ -65,7 +65,6 @@ public class ContentProviderTest extends AndroidTestCase {
 
     @Override
     protected void tearDown() throws Exception {
-        super.tearDown();
         ExtendedSQLiteOpenHelper helper = new ExtendedSQLiteOpenHelper(getContext());
         SQLiteDatabase db = helper.getWritableDatabase();
         db.execSQL("DROP TABLE IF EXISTS `" + TABLE_NAME + "`");

--- a/core/src/androidTest/java/novoda/lib/sqliteprovider/ContentProviderTest.java
+++ b/core/src/androidTest/java/novoda/lib/sqliteprovider/ContentProviderTest.java
@@ -15,7 +15,7 @@ public class ContentProviderTest extends AndroidTestCase {
 
     private static final String TABLE_NAME = "test";
     private static final String COLUMN_PRIMARY_KEY = "column_primary_key";
-    private static final String COLUMN2 = "column2";
+    private static final String ANY_COLUMN = "any_column";
 
     public ContentProviderTest() {
         super();
@@ -33,7 +33,7 @@ public class ContentProviderTest extends AndroidTestCase {
         givenATableWithData();
 
         ContentValues values = new ContentValues(1);
-        values.put(COLUMN2, 1);
+        values.put(ANY_COLUMN, 1);
 
         int numRows = new ExtendedSQLiteOpenHelper(getContext())
                 .getWritableDatabase()
@@ -55,11 +55,11 @@ public class ContentProviderTest extends AndroidTestCase {
         SQLiteDatabase db = helper.getWritableDatabase();
         db.execSQL("CREATE TABLE IF NOT EXISTS `" + TABLE_NAME + "` (" +
                            "`" + COLUMN_PRIMARY_KEY + "` INTEGER PRIMARY KEY," +
-                           "`" + COLUMN2 + "` INTEGER UNIQUE)");
+                           "`" + ANY_COLUMN + "` INTEGER UNIQUE)");
 
         ContentValues values = new ContentValues(2);
         values.put(COLUMN_PRIMARY_KEY, 1);
-        values.put(COLUMN2, 1);
+        values.put(ANY_COLUMN, 1);
         helper.getWritableDatabase().insert(TABLE_NAME, null, values);
     }
 

--- a/core/src/androidTest/java/novoda/lib/sqliteprovider/sqlite/InsertHelperTest.java
+++ b/core/src/androidTest/java/novoda/lib/sqliteprovider/sqlite/InsertHelperTest.java
@@ -143,7 +143,7 @@ public class InsertHelperTest extends AndroidTestCase {
         }
     }
 
-    private static interface CursorOperations {
+    private interface CursorOperations {
         void doOperationsOn(Cursor cursor);
     }
 }

--- a/core/src/main/java/novoda/lib/sqliteprovider/provider/SQLiteContentProviderImpl.java
+++ b/core/src/main/java/novoda/lib/sqliteprovider/provider/SQLiteContentProviderImpl.java
@@ -5,7 +5,6 @@ import android.content.ContentValues;
 import android.content.Context;
 import android.database.Cursor;
 import android.database.DatabaseUtils;
-import android.database.SQLException;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
 import android.net.Uri;
@@ -96,14 +95,12 @@ public class SQLiteContentProviderImpl extends SQLiteContentProvider {
     protected int updateInTransaction(Uri uri, ContentValues values, String selection, String[] selectionArgs) {
         ContentValues insertValues = (values != null) ? new ContentValues(values) : new ContentValues();
 
-        int rowId = getWritableDatabase().update(UriUtils.getItemDirID(uri), insertValues, selection, selectionArgs);
+        int rowsAffected = getWritableDatabase().update(UriUtils.getItemDirID(uri), insertValues, selection, selectionArgs);
 
-        if (rowId > 0) {
-            Uri insertUri = ContentUris.withAppendedId(uri, rowId);
-            notifyUriChange(insertUri);
-            return rowId;
+        if (rowsAffected > 0) {
+            notifyUriChange(uri);
         }
-        throw new SQLException("Failed to update row into " + uri + " because it does not exists.");
+        return rowsAffected;
     }
 
     @Override


### PR DESCRIPTION
#### Problem
The content provider implementation was throwing a `SQLException` when trying to run an update and there were no rows matching the selection arguments. This is breaking the sqlite contract, as it should return the number of affected rows (see [Android documentation](https://developer.android.com/reference/android/database/sqlite/SQLiteDatabase.html#update(java.lang.String, android.content.ContentValues, java.lang.String, java.lang.String[]))). The underlying `SQLiteDatabase` could throw a `SQLiteConstraintException` in case of a constraint violation, but that's none of the provider's business.

#### Solution
Remove the thrown exception, and just return the number of affected rows. Also, notify the correct `Uri` if something has been updated, as previously a wrong `Uri` was notified for the change, because there was the assumption that `SQLiteDatabase.update()` returns an ID, not the number of affected rows. 😛 

#### Tests
Yes, added test in `ContentProviderTest` that is showcasing the correct behaviour.

Also, this fixes #22 :)

Paired with @lgvalle 