### PR TITLE
Fix gradle error

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -6,8 +6,8 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.2.2'
-        classpath 'com.novoda:bintray-release:0.2.10'
+        classpath 'com.android.tools.build:gradle:2.2.2'
+        classpath 'com.novoda:bintray-release:0.4.0'
     }
 }
 

--- a/demo-extended/build.gradle
+++ b/demo-extended/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.2.2'
+        classpath 'com.android.tools.build:gradle:2.2.2'
     }
 }
 

--- a/demo-simple/build.gradle
+++ b/demo-simple/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.2.2'
+        classpath 'com.android.tools.build:gradle:2.2.2'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Sep 28 13:32:32 BST 2014
+#Fri Nov 18 20:03:42 GMT 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip


### PR DESCRIPTION
**Problem**
Gradle fails with the following error:

>Gradle sync failed: Cannot access first() element from an empty List

**Solution**
This seems to be related a bintray-release issue that was resolved [here](https://github.com/novoda/bintray-release/issues/56).

Nevertheless the bintray-release used in the core project has not been updated. Using latest bintray-release version (0.4.0) solves the issue as expected.